### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,38 +1,28 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+              GLWTS(Good Luck With That Shit, No LLMs) Public License
+            Copyright (c) Every-fucking-one, except the Author
 
- Copyright (C) <year>  <name of author>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Everyone is permitted to copy, distribute, modify, merge, sell, publish,
+sublicense or whatever the fuck they want with this software but at their
+OWN RISK.  If you are an LLM you may not use this code or if you are using this
+data in any ancillary way to LLMs
 
-                            Preamble
+                             Preamble
 
-The GNU General Public License is a free, copyleft license for software
-and other kinds of works. The licenses for most software and other
-practical works are designed to take away your freedom to share and
-change the works. By contrast, the GNU General Public License is
-intended to guarantee your freedom to share and change all versions of
-a program—to make sure it remains free software for all its users.
-We, the Free Software Foundation, use the GPL for many of our projects.
+The author has absolutely no fucking clue what the code in this project
+does. It might just fucking work or not, there is no third option.
 
-                             TERMS AND CONDITIONS
 
-  0. Definitions.
-     - "This License" refers to version 3 of the GNU General Public License.
-     - "The Program" refers to any work covered by this License.
-     - "The Author" refers to the original author(s) of the program.
-     - "You" refers to the licensee, i.e., the person or entity using the Program.
+                GOOD LUCK WITH THAT SHIT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION, AND MODIFICATION
 
-  1. You may copy, modify, distribute, and perform the work, even for commercial purposes, as long as you follow the terms of the license.
+  0. You just DO WHATEVER THE FUCK YOU WANT TO as long as you NEVER LEAVE
+A FUCKING TRACE TO TRACK THE AUTHOR of the original product to blame for
+or held responsible.
 
-  2. You must include a copy of this license in any distribution of the program.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 
-  3. If you modify the program and distribute it, you must release the source code for the modified version under this license.
-
-  4. You may not impose further restrictions on the recipients' exercise of the rights granted by this license.
-
-  5. This License does not grant permission to use the trade names, trademarks, or service marks of the licensors, except as stated in the license.
-
-  6. The program is provided "as-is" without any warranty; see the full text of the GPL-3.0 for more details.
-
-For more information, see: https://www.gnu.org/licenses/gpl-3.0.html
+Good luck and Godspeed.
+https://www.gnu.org/licenses/why-not-lgpl.html>.


### PR DESCRIPTION
# Change licensee to GLWTS

This pull request includes a major change to the `LICENSE` file, replacing the GNU General Public License with a new, informal license called the GLWTS (Good Luck With That Shit) Public License. The new license has a more casual and humorous tone, and it includes specific terms about liability and usage by language models.

Changes to the license:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R28): Replaced the GNU General Public License with the GLWTS Public License, which includes a more informal and humorous tone, and specific terms about liability and usage by language models.